### PR TITLE
Default state option to true only if it wasn't already set

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -47,12 +47,12 @@ function Strategy(options, verify) {
 
   options = options || {};
 
-  // Force options.state to true (Now required by LINE v2)
+  // Default options.state to true (Now required by LINE v2)
   // passport-oauth handles this and generates a unique state identification for the request
   // This identification is then saved in Session (by default) and compared when response arrives
   // NOTE: that now this requires you to use express-session (or a similar) session plugin
   // Optionally you can use your own state store. See passport-oauth2 for more information.
-  options.state = true;
+  options.state = options.state || true;
 
   options.clientID = options.channelID;
   options.clientSecret = options.channelSecret;


### PR DESCRIPTION
Having the `state` option forced to `true` disables the possibility that `passport-oauth2` provides of having an own store to generate the state.

This change defaults `state` to `true` but only if it wasn't previously defined.

Thanks 🙂 